### PR TITLE
Add more clarification about docs format

### DIFF
--- a/docs/pages.js
+++ b/docs/pages.js
@@ -4,6 +4,9 @@
  * 
  * Documentation pages can have aliases. To do this, put the name and aliases in an array like ["filename", "alias", "alias2", ...]
  * Titles are automatically generated from the original page's name.
+ *
+ * So, the format is as follows:
+ * ["exact/file-path/from-docs-directory", "an/alias/path", "another-alias/path"]
  */
 loadDocs([
     ["index", "home", "/"]


### PR DESCRIPTION
The docs.js file didn't have enough information about paths. This includes some more.